### PR TITLE
Adding known host key and project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This actions deploys your docker-compose stack file to remote host where docker-
 ### `ssh_host`
 Remote host where docker is running
 
+### `known_host_key`
+Remote host key information for `known_hosts` file
+Example: `"170.64.163.217 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAABIKvgeZ/twOBTN2B2MY/f931XhbW0p0zXjBZgL+R1IW7D"`
+
 ### `ssh_port`
 SSH port on remote host
 
@@ -44,6 +48,7 @@ steps:
   - uses: chaplyk/docker-compose-remote-action@v1.1
     with:
       ssh_host: 127.0.0.1
+      known_host_key: ${{ secrets.KNOWN_HOST_KEY }}
       ssh_user: username
       ssh_key: ${{ secrets.SSH_KEY }}
       compose_file: docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This actions deploys your docker-compose stack file to remote host where docker-
 
 ## Inputs
 
+### `project_name`
+Project name of the compose project
+
 ### `ssh_host`
 Remote host where docker is running
 
@@ -47,11 +50,11 @@ steps:
   - uses: actions/checkout@v2
   - uses: chaplyk/docker-compose-remote-action@v1.1
     with:
+      project_name: projectX
       ssh_host: 127.0.0.1
       known_host_key: ${{ secrets.KNOWN_HOST_KEY }}
       ssh_user: username
       ssh_key: ${{ secrets.SSH_KEY }}
-      compose_file: docker-compose.yml
       pull: true
       build: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   ssh_host:
     description: Remote host where docker is running
     required: true
+  known_host_key:
+    description: Remote host information for "known_host" file
+    required: true
   ssh_port:
     description: Remote port to use, defaults at 22
     required: false

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,9 @@ name: Docker Compose Remote Deploy
 author: Bohdan Chaplyk <bogdan.chaplyk@gmail.com>
 description: 'Deploy docker-compose with remote docker context'
 inputs:
+  project_name:
+    description: Project name of the compose project
+    required: true
   ssh_key:
     description: SSH private key used to connect to the docker host
     required: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 
 # check if required paramethers provided
+if [ -z "$INPUT_PROJECT_NAME" ]; then
+  echo "Input project_name is required!"
+  exit 1
+fi
+
+# check if required paramethers provided
 if [ -z "$INPUT_SSH_KEY" ]; then
   echo "Input ssh_key is required!"
   exit 1
@@ -34,11 +40,6 @@ else
   INPUT_FORCE_RECREATE=''
 fi
 
-# set INPUT_COMPOSE_FILE variable if not provided
-if [ -z "$INPUT_COMPOSE_FILE" ]; then
-  INPUT_COMPOSE_FILE='docker-compose.yml'
-fi
-
 # set INPUT_SSH_PORT variable if not provided
 if [ -z "$INPUT_SSH_PORT" ]; then
   INPUT_SSH_PORT=22
@@ -61,11 +62,11 @@ docker context use remote
 
 # pull latest images if paramether provided
 if [ "$INPUT_PULL" == 'true' ]; then
-  docker-compose -f $INPUT_COMPOSE_FILE pull
+  docker-compose -p $INPUT_PROJECT_NAME pull
 fi
 
 # deploy stack
-docker-compose -f $INPUT_COMPOSE_FILE up -d $INPUT_BUILD $INPUT_FORCE_RECREATE $INPUT_OPTIONS $INPUT_SERVICE
+docker-compose -p $INPUT_PROJECT_NAME up -d $INPUT_BUILD $INPUT_FORCE_RECREATE $INPUT_OPTIONS $INPUT_SERVICE
 
 # cleanup context
 docker context use default 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,11 @@ if [ -z "$INPUT_SSH_HOST" ]; then
   exit 1
 fi
 
+if [ -z "$INPUT_KNOWN_HOST_KEY" ]; then
+  echo "Input known_host_key is required!"
+  exit 1
+fi
+
 # set correct values to paramethers
 if [ "$INPUT_BUILD" == 'true' ]; then
   INPUT_BUILD='--build'
@@ -39,8 +44,12 @@ if [ -z "$INPUT_SSH_PORT" ]; then
   INPUT_SSH_PORT=22
 fi
 
-# create private key and add it to authentication agent
 mkdir -p $HOME/.ssh
+
+# add host to known hosts
+echo $INPUT_KNOWN_HOST_KEY > "$HOME/.ssh/known_hosts"
+
+# create private key and add it to authentication agent
 printf '%s\n' "$INPUT_SSH_KEY" > "$HOME/.ssh/private_key"
 chmod 600 "$HOME/.ssh/private_key"
 eval $(ssh-agent)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,7 +62,7 @@ docker context use remote
 
 # pull latest images if paramether provided
 if [ "$INPUT_PULL" == 'true' ]; then
-  docker-compose -p $INPUT_PROJECT_NAME pull
+  docker-compose -p $INPUT_PROJECT_NAME pull $INPUT_SERVICE
 fi
 
 # deploy stack


### PR DESCRIPTION
This is a bit of an odd one but with current versions of docker and compose I was not able to use this action.

1. The main error was that it requires the project name to correctly find the running docker compose on the remote host, so I've added this as an argument
2. The `Host key verification failed.` error that pops up on every run is very annoying, so I've added an argument to hide it bu actually passing the host key information. Maybe I should make it optional though...

I'm using my fork at the moment and things seem to be working pretty nice!